### PR TITLE
Feature/pour instruction display

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -3,6 +3,9 @@
 	<head>
 		<meta charset="utf-8" />
 		<link rel="icon" href="%sveltekit.assets%/favicon.png" />
+		<link rel="preconnect" href="https://fonts.googleapis.com">
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+		<link href="https://fonts.googleapis.com/css2?family=Share+Tech+Mono&display=swap" rel="stylesheet">
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 		%sveltekit.head%
 	</head>

--- a/src/lib/components/FinalRecipeComponent.svelte
+++ b/src/lib/components/FinalRecipeComponent.svelte
@@ -4,7 +4,7 @@ import CoffeeBeanIcon from "./icons/CoffeeBeanIcon.svelte";
     let {totalCoffeeGrounds, totalWaterAmount} = $props()
 </script>
 
-<div id="RecipeContainer" class="w-5/6 text-slate-100 place-content-center font-medium text-5xl font-mono">
+<div id="RecipeContainer" class="w-full text-slate-100 grid justify-items-center font-medium text-5xl font-mono">
     <p class="text-base font-thin text-center mb-2">Final Recipe</p>
     <hr class="w-48 h-0 mx-auto opacity-30 rounded">
 

--- a/src/lib/components/PourAmountComponent.svelte
+++ b/src/lib/components/PourAmountComponent.svelte
@@ -1,0 +1,35 @@
+<script>
+    import CoffeeBeanIcon from "./icons/CoffeeBeanIcon.svelte";
+    import WaterDropIcon from "./icons/WaterDropIcon.svelte";
+    
+        let {totalCoffeeGrounds, totalWaterAmount} = $props()
+        let individualPourAmount = $derived(totalWaterAmount / 5)
+    </script>
+    
+    <div id="RecipeContainer" class="w-full text-slate-100 grid justify-center font-medium font-mono text-5xl">
+        <p class="text-base font-thin text-center mb-2">Final Recipe</p>
+        <hr class="w-48 h-0 mx-auto opacity-30 rounded">
+
+        <div id="MiniRecipeDisplay" class="w-full flex justify-center text-base mt-2">
+            <div class=" w-80 grid grid-cols-12">
+                <div class="col-span-1 font-mono flex">
+                    <i class=""><WaterDropIcon displaySize="small" /></i>
+                    <p class="">{totalWaterAmount}ml</p>
+                </div>
+                <div class="col-span-1 col-end-12 font-mono flex">
+                    <i class=""><CoffeeBeanIcon size="extrasmall" /></i>
+                    <p class="ml-1">{totalCoffeeGrounds}g</p>
+                </div>
+            </div>
+        </div>
+        
+        <div class="w-full flex justify-center py-6">
+            <p class="text-base font-extrabold bg-zinc-700 px-2 rounded-md">James Hoffmann: Simple Method</p>
+        </div>
+    
+        <div id="PourAmountContainer" class="w-full grid justify-items-center text-xl font-mono">
+            {#each Array(5) as item, i}
+                <p class="pt-1">Pour {i + 1}: {individualPourAmount * (i + 1)}ml</p>
+            {/each}
+        </div>
+    </div>

--- a/src/lib/components/PourAmountComponent.svelte
+++ b/src/lib/components/PourAmountComponent.svelte
@@ -3,9 +3,19 @@
     import WaterDropIcon from "./icons/WaterDropIcon.svelte";
     
         let {totalCoffeeGrounds, totalWaterAmount} = $props()
-        // let individualPourAmount = $derived(totalWaterAmount / 5)'
-        let firstPourAmount = $derived(Math.floor(totalWaterAmount / 5))
+        let divisibleByFourOffset = $state(0)
+        let firstPourAmount = $derived(Math.floor(totalWaterAmount / 5) - divisibleByFourOffset)
         let divisiblePourAmount = $derived((totalWaterAmount - firstPourAmount) / 4)
+        
+
+        $effect(() => {
+            divisibleByFourOffset = 0
+            let fakevar = totalWaterAmount
+        })
+
+        $effect(() => {
+            if((totalWaterAmount - firstPourAmount) % 4 !== 0) divisibleByFourOffset++
+        })
 
     </script>
     

--- a/src/lib/components/PourAmountComponent.svelte
+++ b/src/lib/components/PourAmountComponent.svelte
@@ -37,7 +37,7 @@
             </div>
             {#each Array(4) as item, i}
                 <div class="flex">
-                    <p class="pt-1">Pour {i + 1}: {firstPourAmount + divisiblePourAmount * (i + 1)}ml</p>
+                    <p class="pt-1">Pour {i + 2}: {firstPourAmount + divisiblePourAmount * (i + 1)}ml</p>
                     <p class="ml-5 text-green-400">+{divisiblePourAmount}ml</p>
                 </div>
             {/each}

--- a/src/lib/components/PourAmountComponent.svelte
+++ b/src/lib/components/PourAmountComponent.svelte
@@ -41,20 +41,24 @@
         </div>
     
         <div id="PourAmountContainer" class="w-full grid justify-items-center text-xl font-mono">
-            <div class="w-60 flex justify-center">
-                <div class="w-full grid grid-cols-2 justify-items-center">
-                    <p>Pour 1: </p>
-                    <p>{firstPourAmount}ml</p>
+            <div class="w-60 grid grid-cols-12">
+                <div class="col-span-1"></div>
+                <div class="col-span-8">
+                    <div class="w-full grid grid-cols-2 justify-items-center">
+                        <p>Pour 1: </p>
+                        <p>{firstPourAmount}ml</p>
+                    </div>
                 </div>
-                <p class="ml-5 text-green-400">+{firstPourAmount}ml</p>
+                <p class="ml-2 lg:ml-5 text-green-400 col-span-2">+{firstPourAmount}ml</p>
             </div>
             {#each Array(4) as item, i}
-                <div class="w-60 flex justify-center">
-                    <div class="w-full grid grid-cols-2 justify-items-center">
+                <div class="w-60 grid grid-cols-12">
+                    <div class="col-span-1"></div>
+                    <div class="w-full col-span-8 grid grid-cols-2 justify-items-center">
                         <p class="pt-1">Pour {i + 2}: </p>
                         <p>{firstPourAmount + divisiblePourAmount * (i + 1)}ml</p>
                     </div>
-                    <p class="ml-5 text-green-400">+{divisiblePourAmount}ml</p>
+                    <p class="ml-2 lg:ml-5 text-green-400 col-span-2">+{divisiblePourAmount}ml</p>
                 </div>
             {/each}
         </div>

--- a/src/lib/components/PourAmountComponent.svelte
+++ b/src/lib/components/PourAmountComponent.svelte
@@ -19,7 +19,7 @@
 
     </script>
     
-    <div id="RecipeContainer" class="w-full text-slate-100 grid justify-items-center font-medium font-mono text-5xl">
+    <div id="PourAmountContainer" class="w-full text-slate-100 grid justify-items-center font-medium font-mono text-5xl">
         <p class="text-base font-thin text-center mb-2">Final Recipe</p>
         <hr class="w-48 h-0 mx-auto opacity-30 rounded">
 

--- a/src/lib/components/PourAmountComponent.svelte
+++ b/src/lib/components/PourAmountComponent.svelte
@@ -13,12 +13,12 @@
         <div id="MiniRecipeDisplay" class="w-full flex justify-center text-base mt-2">
             <div class=" w-80 grid grid-cols-12">
                 <div class="col-span-1 font-mono flex">
-                    <i class=""><WaterDropIcon displaySize="small" /></i>
-                    <p class="">{totalWaterAmount}ml</p>
-                </div>
-                <div class="col-span-1 col-end-12 font-mono flex">
                     <i class=""><CoffeeBeanIcon size="extrasmall" /></i>
                     <p class="ml-1">{totalCoffeeGrounds}g</p>
+                </div>
+                <div class="col-span-1 col-end-12 font-mono flex">
+                    <i class=""><WaterDropIcon displaySize="small" /></i>
+                    <p class="">{totalWaterAmount}ml</p>
                 </div>
             </div>
         </div>

--- a/src/lib/components/PourAmountComponent.svelte
+++ b/src/lib/components/PourAmountComponent.svelte
@@ -41,13 +41,19 @@
         </div>
     
         <div id="PourAmountContainer" class="w-full grid justify-items-center text-xl font-mono">
-            <div class="flex">
-                <p class="pt-1">Pour 1: {firstPourAmount}ml</p>
+            <div class="w-60 flex justify-center">
+                <div class="w-full grid grid-cols-2 justify-items-center">
+                    <p>Pour 1: </p>
+                    <p>{firstPourAmount}ml</p>
+                </div>
                 <p class="ml-5 text-green-400">+{firstPourAmount}ml</p>
             </div>
             {#each Array(4) as item, i}
-                <div class="flex">
-                    <p class="pt-1">Pour {i + 2}: {firstPourAmount + divisiblePourAmount * (i + 1)}ml</p>
+                <div class="w-60 flex justify-center">
+                    <div class="w-full grid grid-cols-2 justify-items-center">
+                        <p class="pt-1">Pour {i + 2}: </p>
+                        <p>{firstPourAmount + divisiblePourAmount * (i + 1)}ml</p>
+                    </div>
                     <p class="ml-5 text-green-400">+{divisiblePourAmount}ml</p>
                 </div>
             {/each}

--- a/src/lib/components/PourAmountComponent.svelte
+++ b/src/lib/components/PourAmountComponent.svelte
@@ -3,10 +3,13 @@
     import WaterDropIcon from "./icons/WaterDropIcon.svelte";
     
         let {totalCoffeeGrounds, totalWaterAmount} = $props()
-        let individualPourAmount = $derived(totalWaterAmount / 5)
+        // let individualPourAmount = $derived(totalWaterAmount / 5)'
+        let firstPourAmount = $derived(Math.floor(totalWaterAmount / 5))
+        let divisiblePourAmount = $derived((totalWaterAmount - firstPourAmount) / 4)
+
     </script>
     
-    <div id="RecipeContainer" class="w-full text-slate-100 grid justify-center font-medium font-mono text-5xl">
+    <div id="RecipeContainer" class="w-full text-slate-100 grid justify-items-center font-medium font-mono text-5xl">
         <p class="text-base font-thin text-center mb-2">Final Recipe</p>
         <hr class="w-48 h-0 mx-auto opacity-30 rounded">
 
@@ -28,8 +31,15 @@
         </div>
     
         <div id="PourAmountContainer" class="w-full grid justify-items-center text-xl font-mono">
-            {#each Array(5) as item, i}
-                <p class="pt-1">Pour {i + 1}: {individualPourAmount * (i + 1)}ml</p>
+            <div class="flex">
+                <p class="pt-1">Pour 1: {firstPourAmount}ml</p>
+                <p class="ml-5 text-green-400">+{firstPourAmount}ml</p>
+            </div>
+            {#each Array(4) as item, i}
+                <div class="flex">
+                    <p class="pt-1">Pour {i + 1}: {firstPourAmount + divisiblePourAmount * (i + 1)}ml</p>
+                    <p class="ml-5 text-green-400">+{divisiblePourAmount}ml</p>
+                </div>
             {/each}
         </div>
     </div>

--- a/src/lib/components/SelectionList.svelte
+++ b/src/lib/components/SelectionList.svelte
@@ -44,6 +44,7 @@
         if(customValue < CUSTOM_BUTTON_MIN) customValue = CUSTOM_BUTTON_MIN
         else if(customValue > CUSTOM_BUTTON_MAX) customValue = CUSTOM_BUTTON_MAX
         else customValue = customValue
+        if(selectorName = 'size') customValue = Math.floor(customValue)
 
         currentCustomButton.Value = customValue
         currentCustomButton.Description = CUSTOM_BUTTON_PRESTRING + customValue.toFixed(1) + CUSTOM_BUTTON_POSTSTRING

--- a/src/lib/components/SelectionList.svelte
+++ b/src/lib/components/SelectionList.svelte
@@ -206,7 +206,7 @@
                 <div class="flex flex-row">
                     <p class="font-extralight text-base mx-4 font-serif">{CUSTOM_BUTTON_MIN}</p>
                     <input type="range" on:change={updateCustomButton} bind:value={customValue}
-                     min={CUSTOM_BUTTON_MIN} max={CUSTOM_BUTTON_MAX} step=0.1 />
+                     min={CUSTOM_BUTTON_MIN} max={CUSTOM_BUTTON_MAX} step={selectorName === 'size' ? 0.1 : 1} />
                     <p class="font-extralight text-base mx-4 font-serif">{CUSTOM_BUTTON_MAX}</p>
                 </div>
             </div>

--- a/src/lib/components/icons/CoffeeBeanIcon.svelte
+++ b/src/lib/components/icons/CoffeeBeanIcon.svelte
@@ -1,7 +1,14 @@
 <script>
-    export const size = "small"
+    const {
+        size = "small"
+    } = $props()
+    
 
     const sizeParams = {
+        "extrasmall": {
+            "width": 10,
+            "height": 20
+        },
         "small": {
             "width": 14,
             "height": 25

--- a/src/lib/components/icons/WaterDropIcon.svelte
+++ b/src/lib/components/icons/WaterDropIcon.svelte
@@ -1,11 +1,18 @@
 <script>
-    export const displaySize = "medium"
+    // export const displaySize = "medium"
+    const {
+        displaySize = "medium"
+    } = $props()
 
     const sizeParams =
     {
+        extrasmall: {
+            width: 10,
+            height: 10
+        },
         small: {
-            width: 13,
-            height: 13
+            width: 20,
+            height: 22
         },
 
         medium: {

--- a/src/routes/measurement/[coffeeType]/+layout.svelte
+++ b/src/routes/measurement/[coffeeType]/+layout.svelte
@@ -71,4 +71,6 @@
     </div>
 </div>
 
-<slot />
+<div class="w-5/6 grid justify-items-center">
+    <slot />
+</div>

--- a/src/routes/measurement/[coffeeType]/+layout.svelte
+++ b/src/routes/measurement/[coffeeType]/+layout.svelte
@@ -71,6 +71,6 @@
     </div>
 </div>
 
-<div class="w-5/6 grid justify-items-center">
+<div class="w-full grid justify-items-center">
     <slot />
 </div>

--- a/src/routes/measurement/[coffeeType]/+page.js
+++ b/src/routes/measurement/[coffeeType]/+page.js
@@ -5,6 +5,7 @@ export function load({ params }) {
     return {
         brewData: {
             name: brewData?.name,
+            route: brewData?.route,
             selectionLists: brewData?.selectionLists,
             operation: brewData?.operation
         }

--- a/src/routes/measurement/[coffeeType]/+page.svelte
+++ b/src/routes/measurement/[coffeeType]/+page.svelte
@@ -30,7 +30,7 @@
     }
 
 </script>
-<div class="mt-7 md:mt-10 grid w-full justify-items-center">
+<div class="mt-7 md:mt-10 grid w-full justify-center">
     {#each selectionLists as itemList, i}
         {#key selectionTypes[i]}
             <SelectionList
@@ -47,7 +47,7 @@
 {#if route === "pour"}
     {#if finalDisplayType === "quantity"}
         <div class="w-full grid grid-cols-11">
-            <div class="col-span-9 col-start-2 md:col-start-2">
+            <div class="col-span-9 col-start-2">
                 <FinalRecipeComponent 
                     totalCoffeeGrounds={finalRecipeResults[0]} 
                     totalWaterAmount = {finalRecipeResults[1]}

--- a/src/routes/measurement/[coffeeType]/+page.svelte
+++ b/src/routes/measurement/[coffeeType]/+page.svelte
@@ -46,23 +46,23 @@
 </div>
 {#if route === "pour"}
     {#if finalDisplayType === "quantity"}
-        <div class="w-full grid grid-cols-11">
-            <div class="col-span-9 col-start-2">
+        <div class="w-full grid grid-cols-11 md:grid-cols-5">
+            <div class="col-span-9 md:col-span-3 col-start-2">
                 <FinalRecipeComponent 
                     totalCoffeeGrounds={finalRecipeResults[0]} 
                     totalWaterAmount = {finalRecipeResults[1]}
                 /> 
             </div>
-            <button class="col-span-1 col-start-11" onclick={() => finalDisplayType='pourInstruction'}>
+            <button class="col-span-1 col-start-11 md:col-start-5 flex w-full place-items-center" onclick={() => finalDisplayType='pourInstruction'}>
                 <Icon icon="ic:outline-arrow-forward-ios" color="white" width="32" height="32" />
             </button>
         </div>
     {:else}
-        <div class="w-full grid grid-cols-11">
-            <button class="col-span-1 col-start-1" onclick={() => finalDisplayType='quantity'}>
+        <div class="w-full grid grid-cols-11 md:grid-cols-5">
+            <button class="col-span-1 col-start-1 w-full flex place-items-center" onclick={() => finalDisplayType='quantity'}>
                 <Icon icon="ic:outline-arrow-back-ios" color="white" width="32" height="32" />
             </button>
-            <div class="col-span-9 col-start-2">
+            <div class="col-span-9 md:col-span-3 col-start-2">
                 <PourAmountComponent 
                     totalCoffeeGrounds={finalRecipeResults[0]} 
                     totalWaterAmount={finalRecipeResults[1]}

--- a/src/routes/measurement/[coffeeType]/+page.svelte
+++ b/src/routes/measurement/[coffeeType]/+page.svelte
@@ -30,7 +30,7 @@
     }
 
 </script>
-<div class="mt-7 md:mt-10 flex flex-col place-items-center">
+<div class="mt-7 md:mt-10 grid w-full justify-items-center">
     {#each selectionLists as itemList, i}
         {#key selectionTypes[i]}
             <SelectionList
@@ -53,12 +53,12 @@
                     totalWaterAmount = {finalRecipeResults[1]}
                 /> 
             </div>
-            <button class="col-span-1 col-start-12" onclick={() => finalDisplayType='pourInstruction'}>
+            <button class="col-span-1 col-start-11" onclick={() => finalDisplayType='pourInstruction'}>
                 <Icon icon="ic:outline-arrow-forward-ios" color="white" width="32" height="32" />
             </button>
         </div>
     {:else}
-        <div class="w-full grid grid-cols-12">
+        <div class="w-full grid grid-cols-11">
             <button class="col-span-1 col-start-1" onclick={() => finalDisplayType='quantity'}>
                 <Icon icon="ic:outline-arrow-back-ios" color="white" width="32" height="32" />
             </button>

--- a/src/routes/measurement/[coffeeType]/+page.svelte
+++ b/src/routes/measurement/[coffeeType]/+page.svelte
@@ -20,7 +20,7 @@
         }))
 
     let finalRecipeResults = $derived(operation(selectionVars[0], selectionVars[1], selectionTypes[1]))
-    let finalDisplayType = $state("quantity")
+    let finalDisplayType = $state("pourInstruction")
 
     const ChangeSelectionType = (event, i) => {
         let chosenSelectedType = event.detail
@@ -46,23 +46,24 @@
 </div>
 {#if route === "pour"}
     {#if finalDisplayType === "quantity"}
-        <div class="w-full grid grid-cols-11 md:grid-cols-5">
-            <div class="col-span-9 md:col-span-3 col-start-2">
+        <div class="w-full grid grid-cols-11 lg:grid-cols-5">
+            <div class="col-span-2"></div>
+            <div class="col-span-9 lg:col-span-1 col-start-2">
                 <FinalRecipeComponent 
                     totalCoffeeGrounds={finalRecipeResults[0]} 
                     totalWaterAmount = {finalRecipeResults[1]}
                 /> 
             </div>
-            <button class="col-span-1 col-start-11 md:col-start-5 flex w-full place-items-center" onclick={() => finalDisplayType='pourInstruction'}>
+            <button class="w-full flex col-span-2 col-start-11 md:col-start-5 place-items-center" onclick={() => finalDisplayType='pourInstruction'}>
                 <Icon icon="ic:outline-arrow-forward-ios" color="white" width="32" height="32" />
             </button>
         </div>
     {:else}
         <div class="w-full grid grid-cols-11 md:grid-cols-5">
-            <button class="col-span-1 col-start-1 w-full flex place-items-center" onclick={() => finalDisplayType='quantity'}>
+            <button class=" w-full flex col-span-2 col-start-1 items-center justify-center" onclick={() => finalDisplayType='quantity'}>
                 <Icon icon="ic:outline-arrow-back-ios" color="white" width="32" height="32" />
             </button>
-            <div class="col-span-9 md:col-span-3 col-start-2">
+            <div class="col-span-9 md:col-span-1 col-start-2">
                 <PourAmountComponent 
                     totalCoffeeGrounds={finalRecipeResults[0]} 
                     totalWaterAmount={finalRecipeResults[1]}

--- a/src/routes/measurement/[coffeeType]/+page.svelte
+++ b/src/routes/measurement/[coffeeType]/+page.svelte
@@ -1,6 +1,8 @@
 <script>
     import FinalRecipeComponent from "$lib/components/FinalRecipeComponent.svelte";
+    import PourAmountComponent from "$lib/components/PourAmountComponent.svelte";
     import SelectionList from "$lib/components/SelectionList.svelte";
+    import Icon from "@iconify/svelte";
 	import WaterDropIcon from "$lib/components/icons/WaterDropIcon.svelte";
 
     let {data} = $props()
@@ -18,6 +20,7 @@
         }))
 
     let finalRecipeResults = $derived(operation(selectionVars[0], selectionVars[1], selectionTypes[1]))
+    let finalDisplayType = $state("pourInstruction")
 
     const ChangeSelectionType = (event, i) => {
         let chosenSelectedType = event.detail
@@ -41,8 +44,37 @@
         {/key}
     {/each} 
 </div>
+{#if route === "pour"}
+    {#if finalDisplayType === "quantity"}
+        <div class="w-full grid grid-cols-11">
+            <div class="col-span-9 col-start-2 md:col-start-2">
+                <FinalRecipeComponent 
+                    totalCoffeeGrounds={finalRecipeResults[0]} 
+                    totalWaterAmount = {finalRecipeResults[1]}
+                /> 
+            </div>
+            <button class="col-span-1 col-start-12" onclick={() => finalDisplayType='pourInstruction'}>
+                <Icon icon="ic:outline-arrow-forward-ios" color="white" width="32" height="32" />
+            </button>
+        </div>
+    {:else}
+        <div class="w-full grid grid-cols-12">
+            <button class="col-span-1 col-start-1" onclick={() => finalDisplayType='quantity'}>
+                <Icon icon="ic:outline-arrow-back-ios" color="white" width="32" height="32" />
+            </button>
+            <div class="col-span-9 col-start-2">
+                <PourAmountComponent 
+                    totalCoffeeGrounds={finalRecipeResults[0]} 
+                    totalWaterAmount={finalRecipeResults[1]}
+                /> 
+            </div>
 
-<FinalRecipeComponent 
-    totalCoffeeGrounds={finalRecipeResults[0]} 
-    totalWaterAmount={finalRecipeResults[1]}
-/>
+        </div>
+    {/if}
+
+{:else}
+    <FinalRecipeComponent 
+        totalCoffeeGrounds={finalRecipeResults[0]} 
+        totalWaterAmount = {finalRecipeResults[1]}
+    />
+{/if}

--- a/src/routes/measurement/[coffeeType]/+page.svelte
+++ b/src/routes/measurement/[coffeeType]/+page.svelte
@@ -20,7 +20,7 @@
         }))
 
     let finalRecipeResults = $derived(operation(selectionVars[0], selectionVars[1], selectionTypes[1]))
-    let finalDisplayType = $state("pourInstruction")
+    let finalDisplayType = $state("quantity")
 
     const ChangeSelectionType = (event, i) => {
         let chosenSelectedType = event.detail

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,7 +12,11 @@ export default {
       '4xl': '2.441rem',
       '5xl': '3.052rem',
     },
-    extend: {},
+    extend: {
+      fontFamily: {
+        'mono': ['"Share Tech Mono"', 'monospace']
+      }
+    },
   },
   plugins: [],
 }


### PR DESCRIPTION
Added a new display that acts as a second card in the Pour Over page. This display tells you how much water to pour per pouring session so to speak.

CON: To make the numbers neater, I have decided to remove the ability to set "size" amounts, either coffee or water, to floating point numbers: they must be whole numbers. This makes the pour amounts come out to nice whole numbers.